### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add a `manifest.json` file to folder you want to audit. E.g.
 ```json
 {
   "files": {
-    "src/some_file.ts": {
+    "some_dir/some_file.ts": {
       "source": {
         "git": {
           "repo": "git@github.com:organization/repo.git",
@@ -51,7 +51,7 @@ If you make a patch to a file, you can include the expected diffs in your manife
 ```js
 {
   "files": {
-    "src/some_file.ts": {
+    "some_dir/some_file.ts": {
       "source": {
         "git": {
           "repo": "git@github.com:organization/repo.git",


### PR DESCRIPTION
Currently, the example entries have a path of "src" and a key of "src/some_file.ts". This would mean that the file being checked was "src/src/some_file.ts".

Duplicating "src" seems slightly confusing. Does it make more sense to use a different directory name in the key? I've used "some_dir", but it seems like anything that was not "src" would work.